### PR TITLE
Update control flow

### DIFF
--- a/src/sssom/parsers.py
+++ b/src/sssom/parsers.py
@@ -633,7 +633,16 @@ def from_sssom_rdf(
         )
     )
 
-    return MappingSetRDFConverter().msdf_from_rdf(g, curie_converter=converter, meta=combine_meta)
+    # TODO decide on priority order of contexts
+    # FIXME pop a prefix map from `meta`
+    converter = curies.chain(
+        [
+            curies.Converter.from_rdflib(g),
+            converter,
+        ]
+    )
+
+    return MappingSetRDFConverter(ccp=converter).msdf_from_rdf(g, meta=combine_meta)
 
 
 def from_sssom_json(

--- a/src/sssom/rdf_internal.py
+++ b/src/sssom/rdf_internal.py
@@ -806,7 +806,7 @@ class MappingSetRDFConverter(ObjectConverter):
             # Empty set?
             df = DataFrame()
 
-        return MappingSetDataFrame.with_converter(df=df, metadata=meta, converter=curie_converter)
+        return MappingSetDataFrame.with_converter(df=df, metadata=meta, converter=self.ccp)
 
     @override
     def _init_dict_from_rdf(self, graph: Graph, subject: Node, dest: Dict[str, Any]) -> None:
@@ -870,7 +870,7 @@ class MappingSetRDFConverter(ObjectConverter):
         """
         if graph is None:
             graph = Graph()
-        for k, v in self.curie_converter.bimap.items():
+        for k, v in self.ccp.bimap.items():
             graph.namespace_manager.bind(k, v)
         if hydrate is None:
             hydrate = self.hydrate
@@ -930,9 +930,9 @@ class MappingSetRDFConverter(ObjectConverter):
                 and object_id != NO_TERM_FOUND
                 and predicate_id is not None
             ):
-                subject_ref = URIRef(self.curie_converter.expand(subject_id))
-                pred_ref = URIRef(self.curie_converter.expand(predicate_id))
-                object_ref = URIRef(self.curie_converter.expand(object_id))
+                subject_ref = URIRef(self.ccp.expand(subject_id))
+                pred_ref = URIRef(self.ccp.expand(predicate_id))
+                object_ref = URIRef(self.ccp.expand(object_id))
                 graph.add(cast(Triple, [subject_ref, pred_ref, object_ref]))
 
 

--- a/src/sssom/writers.py
+++ b/src/sssom/writers.py
@@ -371,7 +371,9 @@ PREFIX oboInOwl: <http://www.geneontology.org/formats/oboInOwl#>
 
 def to_rdf_graph(msdf: MappingSetDataFrame, *, hydrate: bool = False) -> Graph:
     """Convert a mapping set dataframe to an RDF graph."""
-    return MappingSetRDFConverter().msdf_to_rdf(msdf, hydrate=hydrate)
+    return MappingSetRDFConverter(hydrate=hydrate, ccp=msdf.converter).msdf_to_rdf(
+        msdf, hydrate=hydrate
+    )
 
 
 EXAMPLE_SPARQL_QUERY = """\


### PR DESCRIPTION
This PR updates the way that curies.Converter objects are passed around in the RDF conversion workflow, consolidating the number of places where the internal state of the RDF converter object is modified to just the `__init__()` of the object